### PR TITLE
New options to delete nfo and img files during the rename process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v1.1.0] - 2025-08-16
+### Added
+- Added new option --no-nfo which deletes nfo files as part of the rename process
+- Added new option --no-img which deletes image files as part of the rename process
+- Updated show demo to include new flag functionality
+
 ## [v1.0.1] - 2025-08-16
 ### Fixed
 - Extra vertical bar next to stat panel.

--- a/Justfile
+++ b/Justfile
@@ -75,7 +75,7 @@ demo target:
 		exit 1
 	fi
 	echo "Entering demo dataset directory: $data_dir"
-	( cd "$data_dir" && echo "Running: title-tidy $mode" && title-tidy "$mode" )
+	( cd "$data_dir" && echo "Running: title-tidy $mode" && title-tidy "$mode" --no-nfo --no-img)
 	echo "Cleaning up demo dataset: $data_dir"
 	rm -rf "$data_dir"
 	echo "Demo $mode complete and cleaned."

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ media files, and you'll see a preview of all proposed changes. Nothing gets rena
 title-tidy [command]
 ```
 
-Add the `-i` or `--instant` flag to apply changes immediately without the interactive preview.
+* Add the `-i` or `--instant` flag to apply changes immediately without the interactive preview.
+* The `--no-nfo` flag will delete nfo files during the rename process.
+* The `--no-img` flag will delete image files during the rename process.
 
 ## Commands
 
@@ -35,7 +37,7 @@ the entire directory structure: show folders, season folders, and all episode fi
 command can process multiple shows at once. Episode files named only after the episode
 will retrieve the season number from the parent directory name. 
 
-![shows demo](https://vhs.charm.sh/vhs-4azhoxRPBT1c1bZ5lcxIWp.gif)
+![shows demo](https://vhs.charm.sh/vhs-5KIKITpGcbCmfDzfZrACo4.gif)
 
 **Before → After examples:**
 ```

--- a/demo/shows/demo.tape
+++ b/demo/shows/demo.tape
@@ -15,7 +15,7 @@ Type "clear"
 Enter
 Show
 
-Type "title-tidy shows"
+Type "title-tidy shows --no-nfo --no-img"
 Sleep 1s
 Enter
 Sleep 500ms

--- a/demo/shows/make.sh
+++ b/demo/shows/make.sh
@@ -11,12 +11,19 @@ SHOW1_DIR="$OUT/$SHOW1_RAW"
 mkdir -p "$SHOW1_DIR/Season 1" "$SHOW1_DIR/s2" "$SHOW1_DIR/Season_03 Extras"
 # Season 1 episodes - direct SxxEyy + lowercase variant + alt 1x07 pattern + dotted
 touch "$SHOW1_DIR/Season 1/Show.Name.S01E01.1080p.mkv"
+touch "$SHOW1_DIR/Season 1/Show.Name.S01E01.1080p.nfo"
+touch "$SHOW1_DIR/Season 1/Show.Name.S01E01.1080p.jpg"
 touch "$SHOW1_DIR/Season 1/show.name.s01e02.mkv"
+touch "$SHOW1_DIR/Season 1/show.name.s01e02.nfo"
 touch "$SHOW1_DIR/Season 1/Show.Name.1x03.mkv"
+touch "$SHOW1_DIR/Season 1/Show.Name.1x03.png"
 touch "$SHOW1_DIR/Season 1/1.04.1080p.mkv"  # dotted pattern -> S01E04
+touch "$SHOW1_DIR/Season 1/1.04.1080p.nfo"
 # Season 2 episodes - context fallback (no season token in filename)
 touch "$SHOW1_DIR/s2/Episode 5.mkv"    # S02E05 via parent
+touch "$SHOW1_DIR/s2/Episode 5.nfo"
 touch "$SHOW1_DIR/s2/E06.mkv"          # S02E06 via parent (E06)
+touch "$SHOW1_DIR/s2/poster.jpg"
 # Season 3 style alt name (Season_03) plus subtitles & dotted season 10 example (ignored here)
 touch "$SHOW1_DIR/Season_03 Extras/10.12.mkv" # S10E12 (season 10) even though under Season 3 folder
 touch "$SHOW1_DIR/Season_03 Extras/Show.Name.S03E01.en.srt"

--- a/internal/core/metadata.go
+++ b/internal/core/metadata.go
@@ -36,15 +36,17 @@ const (
 //     synthesized movie directories wrapping loose video files.
 //   - NeedsDirectory: Signals that a directory must be created before children
 //     are renamed beneath it (typically paired with IsVirtual).
+//   - MarkedForDeletion: True when the file should be deleted during rename operation.
 //
 // The zero value is meaningful: it encodes an untyped, unprocessed node with no rename proposal.
 type MediaMeta struct {
-	Type           MediaType
-	NewName        string
-	RenameStatus   RenameStatus
-	RenameError    string
-	IsVirtual      bool
-	NeedsDirectory bool
+	Type              MediaType
+	NewName           string
+	RenameStatus      RenameStatus
+	RenameError       string
+	IsVirtual         bool
+	NeedsDirectory    bool
+	MarkedForDeletion bool
 }
 
 // GetMeta retrieves the existing *MediaMeta attached to n or nil when absent.

--- a/internal/media/parse.go
+++ b/internal/media/parse.go
@@ -50,6 +50,12 @@ var (
 
 	// simpleNumberRe matches a standalone number that might represent a season.
 	simpleNumberRe = regexp.MustCompile(`^(\d+)|[\s\.\-_](\d+)(?:[\s\.\-_]|$)`)
+
+	// nfoRe matches NFO info file extensions.
+	nfoRe = regexp.MustCompile(`(?i)\.nfo$`)
+
+	// imageRe matches common image file extensions.
+	imageRe = regexp.MustCompile(`(?i)\.(jpg|jpeg|png|gif|bmp|webp|tiff?|ico|svg)$`)
 )
 
 // IsVideo reports whether filename has a recognized video extension.
@@ -62,6 +68,16 @@ func IsSubtitle(filename string) bool {
 	return subtitleRe.MatchString(filename)
 }
 
+// IsNFO reports whether filename has an NFO extension.
+func IsNFO(filename string) bool {
+	return nfoRe.MatchString(filename)
+}
+
+// IsImage reports whether filename has a recognized image extension.
+func IsImage(filename string) bool {
+	return imageRe.MatchString(filename)
+}
+
 // ExtractSubtitleSuffix extracts the language code and extension from subtitle files.
 // For example: "movie.en.srt" returns ".en.srt", "movie.srt" returns ".srt"
 // Also handles cases like "movie.eng.srt", "movie.en-US.srt", etc.
@@ -72,7 +88,7 @@ func ExtractSubtitleSuffix(filename string) string {
 
 	// Find the subtitle extension first
 	subtitleMatch := subtitleRe.FindStringIndex(filename)
-	if subtitleMatch == nil || len(subtitleMatch) == 0 {
+	if len(subtitleMatch) == 0 {
 		return ""
 	}
 

--- a/main.go
+++ b/main.go
@@ -42,6 +42,8 @@ func main() {
 	flags := flag.NewFlagSet(command, flag.ExitOnError)
 	instant := flags.Bool("i", false, "Apply renames immediately without interactive preview")
 	flags.BoolVar(instant, "instant", false, "Apply renames immediately without interactive preview")
+	noNFO := flags.Bool("no-nfo", false, "Delete NFO files during rename")
+	noImages := flags.Bool("no-img", false, "Delete image files during rename")
 	
 	// Parse remaining arguments after the command
 	if err := flags.Parse(os.Args[2:]); err != nil {
@@ -49,8 +51,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	// Set instant mode in config
+	// Set flags in config
 	cfg.InstantMode = *instant
+	cfg.DeleteNFO = *noNFO
+	cfg.DeleteImages = *noImages
 
 	if err := cmd.RunCommand(cfg); err != nil {
 		fmt.Printf("Error: %v\n", err)
@@ -68,4 +72,6 @@ func printUsage() {
 	 fmt.Printf("  title-tidy help      Show this help message\n\n")
 	fmt.Printf("Options:\n")
 	fmt.Printf("  -i, --instant          Apply renames immediately and exit\n")
+	fmt.Printf("  --no-nfo               Delete NFO files during rename\n")
+	fmt.Printf("  --no-img               Delete image files during rename\n")
 }


### PR DESCRIPTION
## [v1.1.0] - 2025-08-16
### Added
- Added new option --no-nfo which deletes nfo files as part of the rename process
- Added new option --no-img which deletes image files as part of the rename process
- Updated show demo to include new flag functionality
